### PR TITLE
Fixed node-alpine version in Dockerfile(s)

### DIFF
--- a/globoapp/Dockerfile
+++ b/globoapp/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:14.5.0-alpine
 
 WORKDIR /usr/app
 

--- a/globoappserver/Dockerfile
+++ b/globoappserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:14.5.0-alpine
 
 WORKDIR '/app'
 


### PR DESCRIPTION
Updated node version with the correct one in Dockerfile(s). The general _node:alpine_ was giving error at startup.